### PR TITLE
Upgrade the mongodb-native driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         }
     ],
     "dependencies": {
-        "mongodb": "0.9.9-7",
+        "mongodb": "1.0.0",
         "pd": "0.6.3"
     },
     "scripts": {


### PR DESCRIPTION
This patch uses the newest version of mongodb-native which is 1.0.0 at the moment.
