### PR TITLE
Update the native mongodb driver dependency to 1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     }
   ],
   "dependencies": {
-    "mongodb": "1.0.0",
+    "mongodb": "1.1.4",
     "pd": "0.6.3"
   },
   "scripts": {


### PR DESCRIPTION
There have been quite a few changes to the native driver since 1.0.0.

https://github.com/mongodb/node-mongodb-native/blob/master/HISTORY#L45

The above links directly to the change log from 1.0.1 to 1.1.4.
